### PR TITLE
Email staff reviewers when internal review opens

### DIFF
--- a/hypha/apply/activity/messaging.py
+++ b/hypha/apply/activity/messaging.py
@@ -867,8 +867,9 @@ class EmailAdapter(AdapterBase):
         return [
             reviewer.email
             for reviewer in source.missing_reviewers.all()
-            if source.phase.permissions.can_review(reviewer) and not reviewer.is_apply_staff
-        ]
+            if source.phase.permissions.can_review(reviewer) and (
+                # don't email staff reviewers unless review is internal
+                not reviewer.is_apply_staff or source.phase.display_name == "Internal Review")]
 
     def partners_updated_applicant(self, added, removed, **kwargs):
         if added:


### PR DESCRIPTION
This draft pull request emails staff reviewers when an internal review opens. Previously non-staff reviewers were emailed for external reviews, but staff was only notified via Slack causing confusion about whether assigning reviewers was functional. Does not email staff about external reviews, even though the permissions should allow them to review then.

Partial fix for ARDC-8 and 23. See also TK