### PR TITLE
Send applicants fewer emails

### DIFF
--- a/hypha/apply/activity/messaging.py
+++ b/hypha/apply/activity/messaging.py
@@ -844,6 +844,10 @@ class EmailAdapter(AdapterBase):
         if message_type in {MESSAGES.REVIEW_REMINDER}:
             return self.reviewers(source)
 
+        if message_type not in {MESSAGES.DETERMINATION_OUTCOME, MESSAGES.BATCH_DETERMINATION_OUTCOME}:
+            # Only send an email alert when: the grant has been determined eligible, ineligible, or needs more information
+            return []
+
         return [source.user.email]
 
     def batch_recipients(self, message_type, sources, **kwargs):


### PR DESCRIPTION
This modifies the messaging system to "only send an email alert when: the grant has been determined eligible, ineligible, or needs more information." (I interpreted "eligible [or] ineligible" to mean a determination of accepted or rejected.)

It does this by returning an empty recipients list except for determinations and some message types that seem not to go to the applicant. This is consistent with how the code seems to define rules like these, but I believe this should probably be configurable instead. Update to come.

## Steps to test
1. Update an application status to something other than a determination. It should send an email.
2. Switch to this branch and restart.
3. Update an application status to something other than a determination. It shouldn't send an email.
4. Update an application to send a determination. It should send an email.

## Deployment
Tested by switching OTS staging to `ardc-fix/fewer-emails` and restarting.

Fixes ARDC-2 and partly fixes ARDC-22