### PR TITLE
Custom workflow state names

### DIFF
--- a/hypha/locale/en_ARDC/LC_MESSAGES/django.po
+++ b/hypha/locale/en_ARDC/LC_MESSAGES/django.po
@@ -1,0 +1,41 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-09-22 17:07+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Internal Review"
+msgstr "GAC Review"
+
+#, python-brace-format
+msgid "{org_short_name} Review"
+msgstr "{org_short_name} Committee Review"
+
+msgid "Open External Review"
+msgstr "Open Board Review"
+
+msgid "Open Internal Review (revert)"
+msgstr "Open GAC Review (revert)"
+
+msgid "External Review"
+msgstr "Board Review"
+
+msgid "Open External Review (revert)"
+msgstr "Open Board Review (revert)"
+
+msgid "External Reviewers"
+msgstr "Board Reviewers"

--- a/hypha/settings/base.py
+++ b/hypha/settings/base.py
@@ -326,7 +326,7 @@ PASSWORD_RESET_TIMEOUT_DAYS = 8
 
 # Language code in standard language id format: en, en-gb, en-us
 # The corrosponding locale dir is named: en, en_GB, en_US
-LANGUAGE_CODE = env.get('LANGUAGE_CODE', 'en')
+LANGUAGE_CODE = env.get('LANGUAGE_CODE', 'en_ARDC')
 
 CURRENCY_SYMBOL = env.get('CURRENCY_SYMBOL', '$')
 


### PR DESCRIPTION
Adds a new English locale for ARDC-specific translations. Still deciding if this is the best way to do the translation overlay or if a Django "app" with these is.