### PR TITLE
Permit reviewers to review during internal review

### DIFF
--- a/hypha/apply/funds/workflow.py
+++ b/hypha/apply/funds/workflow.py
@@ -369,7 +369,7 @@ SingleStageExternalDefinition = [
             'display': _('Internal Review'),
             'public': f'{settings.ORG_SHORT_NAME} Review',
             'stage': RequestExt,
-            'permissions': default_permissions,
+            'permissions': reviewer_review_permissions,
         },
     },
     {


### PR DESCRIPTION
This solves a client need to have GAC review members review during internal reviews.